### PR TITLE
Fix Implicitly deprecation

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -51,7 +51,7 @@ class Document implements JsonSerializable
     /**
      * @param ElementInterface $data
      */
-    public function __construct(ElementInterface $data = null)
+    public function __construct(?ElementInterface $data = null)
     {
         $this->data = $data;
     }


### PR DESCRIPTION
Fixes:

_Tobscure\JsonApi\Document::__construct(): Implicitly marking parameter $data as nullable is deprecated, the explicit nullable type must be used instead_