### PR TITLE
php 8.4 Implicitly nullable parameter declarations deprecated

### DIFF
--- a/src/AbstractSerializer.php
+++ b/src/AbstractSerializer.php
@@ -41,7 +41,7 @@ abstract class AbstractSerializer implements SerializerInterface
     /**
      * {@inheritdoc}
      */
-    public function getAttributes($model, array $fields = null)
+    public function getAttributes($model, ?array $fields = null)
     {
         return [];
     }

--- a/src/SerializerInterface.php
+++ b/src/SerializerInterface.php
@@ -39,7 +39,7 @@ interface SerializerInterface
      *
      * @return array
      */
-    public function getAttributes($model, array $fields = null);
+    public function getAttributes($model, ?array $fields = null);
 
     /**
      * Get the links array.


### PR DESCRIPTION
tested by running the joomla integration tests with php 8.4

`npx cypress run --spec '.\tests\System\integration\api\com_config\'`

This pr fixes the deprecation notice

```
[19-Mar-2025 21:55:34 UTC] PHP Deprecated:  Tobscure\JsonApi\AbstractSerializer::getAttributes(): Implicitly marking parameter $fields as nullable is deprecated, the explicit nullable type must be used instead in D:\repos\j51\libraries\vendor\tobscure\json-api\src\AbstractSerializer.php on line 44
[19-Mar-2025 21:55:34 UTC] PHP Deprecated:  Tobscure\JsonApi\SerializerInterface::getAttributes(): Implicitly marking parameter $fields as nullable is deprecated, the explicit nullable type must be used instead in D:\repos\j51\libraries\vendor\tobscure\json-api\src\SerializerInterface.php on line 42
```