### PR TITLE
Implicitly nullable parameters are deprecated.

### DIFF
--- a/src/Relationship.php
+++ b/src/Relationship.php
@@ -28,7 +28,7 @@ class Relationship
      *
      * @param \Tobscure\JsonApi\ElementInterface|null $data
      */
-    public function __construct(ElementInterface $data = null)
+    public function __construct(?ElementInterface $data = null)
     {
         $this->data = $data;
     }


### PR DESCRIPTION
simple change to explicitly mark the $data param as nullable

Created as I spotted the following log entry after running cypress tests on joomla 5.3

>  PHP Deprecated:  Tobscure\JsonApi\Relationship::__construct(): Implicitly marking parameter $data as nullable is deprecated, the explicit nullable type must be used instead in D:\repos\j51\libraries\vendor\tobscure\json-api\src\Relationship.php on line 31

once merged joomla-cms will need to be updated to use this version